### PR TITLE
Fix port conflict between PostfixAdmin and Roundcube

### DIFF
--- a/mail-server/docker-compose.yml
+++ b/mail-server/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     image: postfixadmin:latest
     container_name: postfixadmin
     ports:
-      - "8080:80"
+      - "8081:80"  # Changed from 8080 to 8081 to avoid conflict with Roundcube
     environment:
       - POSTFIXADMIN_DB_TYPE=sqlite
       - POSTFIXADMIN_DB_HOST=sqlite:/data/postfixadmin.db


### PR DESCRIPTION
## Issue Fixed

This PR fixes a port conflict between PostfixAdmin and Roundcube webmail. Both were configured to use port 8080, which caused Roundcube to be inaccessible.

## Changes Made

- Changed PostfixAdmin port from 8080 to 8081 in docker-compose.yml

## How to Access Services After This Change

- Roundcube webmail: http://[YOUR_SERVER_IP]:8080
- PostfixAdmin: http://[YOUR_SERVER_IP]:8081

This ensures both services can run simultaneously without conflicts.